### PR TITLE
Only load vendored code if Chef not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ Omnijack Gem CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Don't load vendored Chef classes if Chef itself is already loaded
 
 v0.1.0 (2014-09-12)
 -------------------
 - Initial release!
-
 
 v0.0.1 (2014-09-02)
 -------------------

--- a/lib/omnijack.rb
+++ b/lib/omnijack.rb
@@ -16,8 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../vendor/chef/lib/chef/exceptions'
-require_relative '../vendor/chef/lib/chef/mixin/params_validate'
+unless Module.const_defined?(:Chef)
+  require_relative '../vendor/chef/lib/chef/exceptions'
+  require_relative '../vendor/chef/lib/chef/mixin/params_validate'
+end
 require_relative 'omnijack/config'
 require_relative 'omnijack/project'
 require_relative 'omnijack/list'

--- a/lib/omnijack/config.rb
+++ b/lib/omnijack/config.rb
@@ -16,9 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../../vendor/chef/lib/chef/exceptions'
-require_relative '../../vendor/chef/lib/chef/mixin/params_validate'
-
 class Omnijack
   # Offer a config to base all the metaruby off of
   #

--- a/lib/omnijack/metadata.rb
+++ b/lib/omnijack/metadata.rb
@@ -20,8 +20,6 @@ require 'ohai'
 require 'open-uri'
 require_relative 'config'
 require_relative '../omnijack'
-require_relative '../../vendor/chef/lib/chef/exceptions'
-require_relative '../../vendor/chef/lib/chef/mixin/params_validate'
 
 class Omnijack
   # A class for representing an Omnitruck metadata object

--- a/lib/omnijack/project.rb
+++ b/lib/omnijack/project.rb
@@ -22,8 +22,6 @@ require_relative 'list'
 require_relative 'metadata'
 require_relative 'platforms'
 require_relative 'project/metaprojects'
-require_relative '../../vendor/chef/lib/chef/exceptions'
-require_relative '../../vendor/chef/lib/chef/mixin/params_validate'
 
 class Omnijack
   # A parent project that can contain metadata, a pkg list, and platforms


### PR DESCRIPTION
Otherwise Ruby generates warnings from trying to redefine Chef classes.
