### PR TITLE
Decode package URL when generating filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Omnijack Gem CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Fix encoding issue with incorrect filename for nightly build packages
 
 v0.1.1 (2014-09-12)
 -------------------

--- a/features/step_definitions/metadata.rb
+++ b/features/step_definitions/metadata.rb
@@ -7,7 +7,7 @@ Then(/^the metadata (has|doesn't have) a(n)? (\w+) attribute$/) do |has, _, a|
             when 'url'
               %r{^https://opscode-omnibus-packages\.s3\.amazonaws\.com.*$}
             when 'filename'
-              /^[A-Za-z0-9_\.\-%]+\.(rpm|deb|pkg|msi)$/
+              /^[A-Za-z0-9_\.\-\+]+\.(rpm|deb|pkg|msi)$/
             when 'md5'
               /^\w{32}$/
             when 'sha256'

--- a/lib/omnijack/metadata.rb
+++ b/lib/omnijack/metadata.rb
@@ -66,7 +66,7 @@ class Omnijack
               else line.split[1]
               end
         hsh[key] = val
-        hsh[:filename] = val.split('/')[-1] if key == :url
+        hsh[:filename] = URI.decode(val).split('/')[-1] if key == :url
       end
     end
 

--- a/spec/omnijack/config_spec.rb
+++ b/spec/omnijack/config_spec.rb
@@ -42,7 +42,7 @@ describe Omnijack::Config do
           # Some endpoints aren't available on Chef's public Omnitruck API
           if [:angry_chef, :chef_dk, :chef_container].include?(project) && \
             [:package_list, :platform_names].include?(name)
-            expected = 404
+            expected = 301
           else
             expected = 200
           end

--- a/spec/support/real_test_data.json
+++ b/spec/support/real_test_data.json
@@ -5,10 +5,10 @@
     "prerelease": false,
     "nightlies": false,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.2.1-1_amd64.deb",
-      "filename": "chefdk_0.2.1-1_amd64.deb",
-      "md5": "2decbcacd464371704f008380a876ef8",
-      "sha256": "ec6f27af170e55d3510904f745d778bbf245dbd14034cacecf2aab8992936733"
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.2.2-1_amd64.deb",
+      "filename": "chefdk_0.2.2-1_amd64.deb",
+      "md5": "1b097776840aa10f092063d1579bf155",
+      "sha256": "a6384851473779d3b0d0bedc509607b924751ea3b356e7df4b9c7ab16dd25788"
     }
   },
   {
@@ -36,95 +36,95 @@
     "prerelease": false,
     "nightlies": true,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.2.2%2B20140914085111.git.1.e34ac9c-1_amd64.deb",
-      "filename": "chefdk_0.2.2%2B20140914085111.git.1.e34ac9c-1_amd64.deb",
-      "md5": "cb08d4bd1a675c92410e56f27dbb61f2",
-      "sha256": "ce5ca62caa1730e83fe5b8dfb4e93da4d2ed3c20261ec389bc02e6e68f0f8bc5"
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.2.2%2B20140917085111.git.23.997cf31-1_amd64.deb",
+      "filename": "chefdk_0.2.2+20140917085111.git.23.997cf31-1_amd64.deb",
+      "md5": "03af55494419a3b3b32617fb76141ffc",
+      "sha256": "e16c8d8cb594fe0fa82489d348af258f94e3e68ad8392bec31e3f12b5fd80285"
     }
   },
   {
     "platform": {"name": "ubuntu", "version": "13.10" },
-    "version": "0.2.1",
+    "version": "0.2.2",
     "prerelease": false,
     "nightlies": false,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.2.1-1_amd64.deb",
-      "filename": "chefdk_0.2.1-1_amd64.deb",
-      "md5": "2decbcacd464371704f008380a876ef8",
-      "sha256": "ec6f27af170e55d3510904f745d778bbf245dbd14034cacecf2aab8992936733"
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.2.2-1_amd64.deb",
+      "filename": "chefdk_0.2.2-1_amd64.deb",
+      "md5": "1b097776840aa10f092063d1579bf155",
+      "sha256": "a6384851473779d3b0d0bedc509607b924751ea3b356e7df4b9c7ab16dd25788"
     }
   },
   {
     "platform": {"name": "mac_os_x", "version": "10.8" },
-    "version": "0.2.1",
+    "version": "0.2.2",
     "prerelease": false,
     "nightlies": false,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-0.2.1-1.dmg",
-      "filename": "chefdk-0.2.1-1.dmg",
-      "md5": "4374d8f8f290b3efab6d02b5cedb48d7",
-      "sha256": "d4a6023e21c2c3cfb6773382ae7d6111e2de44ac1064aa2b1c0faddcd3bc1d13"
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-0.2.2-1.dmg",
+      "filename": "chefdk-0.2.2-1.dmg",
+      "md5": "2d0d8881ef6b0cdcbaedfacac2d5129d",
+      "sha256": "4922390a2dc08c26947fe8ed94a3a1777bd820e0e409e4072b2fb1315f4425d5"
     }
   },
   {
     "platform": {"name": "mac_os_x", "version": "10.9" },
-    "version": "0.2.1",
+    "version": "0.2.2",
     "prerelease": false,
     "nightlies": false,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-0.2.1-1.dmg",
-      "filename": "chefdk-0.2.1-1.dmg",
-      "md5": "4374d8f8f290b3efab6d02b5cedb48d7",
-      "sha256": "d4a6023e21c2c3cfb6773382ae7d6111e2de44ac1064aa2b1c0faddcd3bc1d13"
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-0.2.2-1.dmg",
+      "filename": "chefdk-0.2.2-1.dmg",
+      "md5": "2d0d8881ef6b0cdcbaedfacac2d5129d",
+      "sha256": "4922390a2dc08c26947fe8ed94a3a1777bd820e0e409e4072b2fb1315f4425d5"
     }
   },
   {
     "platform": {"name": "centos", "version": "6.5" },
-    "version": "0.2.1",
+    "version": "0.2.2",
     "prerelease": false,
     "nightlies": false,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chefdk-0.2.1-1.el6.x86_64.rpm",
-      "filename": "chefdk-0.2.1-1.el6.x86_64.rpm",
-      "md5": "feb2e06fdecae3bae79f8ec8d32d6ab6",
-      "sha256": "afd487ab6f0cd0286a0a3d2808a041c784c064eddb6193d688edfb6741065b56"
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chefdk-0.2.2-1.x86_64.rpm",
+      "filename": "chefdk-0.2.2-1.x86_64.rpm",
+      "md5": "5da3f329f7e6d51e778212dea4dae73f",
+      "sha256": "2bc4c5c6f82ee7abed385d837e526fd40777ddc47ad939e4f3ecea625b43a245"
     }
   },
   {
     "platform": {"name": "centos", "version": "7.0" },
-    "version": "0.2.1",
+    "version": "0.2.2",
     "prerelease": false,
     "nightlies": false,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chefdk-0.2.1-1.el6.x86_64.rpm",
-      "filename": "chefdk-0.2.1-1.el6.x86_64.rpm",
-      "md5": "feb2e06fdecae3bae79f8ec8d32d6ab6",
-      "sha256": "afd487ab6f0cd0286a0a3d2808a041c784c064eddb6193d688edfb6741065b56",
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chefdk-0.2.2-1.x86_64.rpm",
+      "filename": "chefdk-0.2.2-1.x86_64.rpm",
+      "md5": "5da3f329f7e6d51e778212dea4dae73f",
+      "sha256": "2bc4c5c6f82ee7abed385d837e526fd40777ddc47ad939e4f3ecea625b43a245",
       "yolo": true
     }
   },
   {
     "platform": {"name": "windows", "version": "2008r2" },
-    "version": "0.2.1",
+    "version": "0.2.2",
     "prerelease": false,
     "nightlies": false,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-windows-0.2.1-1.windows.msi",
-      "filename": "chefdk-windows-0.2.1-1.windows.msi",
-      "md5": "218a9d79bcea5c2f8493cd6b7f020224",
-      "sha256": "acdb91228d21dca93d3c67f70f8f7580522e78aaaced2a9f7bf8f2c19e5864d6"
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.2.2-1.msi",
+      "filename": "chefdk-0.2.2-1.msi",
+      "md5": "21f9af35451a0116b72531f06e93eb05",
+      "sha256": "76038621bad5333b9ceee4dc32325cf2a880fa69ef64a9225d91ab1788c37a53"
     }
   },
   {
     "platform": {"name": "windows", "version": "2012" },
-    "version": "0.2.1",
+    "version": "0.2.2",
     "prerelease": false,
     "nightlies": false,
     "expected": {
-      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-windows-0.2.1-1.windows.msi",
-      "filename": "chefdk-windows-0.2.1-1.windows.msi",
-      "md5": "218a9d79bcea5c2f8493cd6b7f020224",
-      "sha256": "acdb91228d21dca93d3c67f70f8f7580522e78aaaced2a9f7bf8f2c19e5864d6",
+      "url": "https://opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.2.2-1.msi",
+      "filename": "chefdk-0.2.2-1.msi",
+      "md5": "21f9af35451a0116b72531f06e93eb05",
+      "sha256": "76038621bad5333b9ceee4dc32325cf2a880fa69ef64a9225d91ab1788c37a53",
       "yolo": true
     }
   }


### PR DESCRIPTION
Nightly builds include an encoded "+" in the URL that needs to be decoded to get the correct filename.
